### PR TITLE
Fix the Gradient has outdated direction syntax errors

### DIFF
--- a/src/providers/Facebook.vue
+++ b/src/providers/Facebook.vue
@@ -204,11 +204,11 @@
   
   // Button facebook style `gradient`
   .facebook__design__gradient {
-    background-image: linear-gradient(bottom, $facebook_main_color, $gradient_color);
-    background-image: -moz-linear-gradient(bottom, $facebook_main_color, $gradient_color);
-    background-image: -o-linear-gradient(bottom, $facebook_main_color, $gradient_color);
-    background-image: -webkit-linear-gradient(bottom, $facebook_main_color, $gradient_color);
-    background-image: -ms-linear-gradient(bottom, $facebook_main_color, $gradient_color);
+    background-image: linear-gradient(to bottom, $facebook_main_color, $gradient_color);
+    background-image: -moz-linear-gradient(to bottom, $facebook_main_color, $gradient_color);
+    background-image: -o-linear-gradient(to bottom, $facebook_main_color, $gradient_color);
+    background-image: -webkit-linear-gradient(to bottom, $facebook_main_color, $gradient_color);
+    background-image: -ms-linear-gradient(to bottom, $facebook_main_color, $gradient_color);
     color: $text_white_color;
   }
   

--- a/src/providers/GooglePlus.vue
+++ b/src/providers/GooglePlus.vue
@@ -141,11 +141,11 @@
   
   // Button googleplus style `gradient`
   .googleplus__design__gradient {
-    background-image: linear-gradient(bottom, $googleplus_main_color, $gradient_color);
-    background-image: -moz-linear-gradient(bottom, $googleplus_main_color, $gradient_color);
-    background-image: -o-linear-gradient(bottom, $googleplus_main_color, $gradient_color);
-    background-image: -webkit-linear-gradient(bottom, $googleplus_main_color, $gradient_color);
-    background-image: -ms-linear-gradient(bottom, $googleplus_main_color, $gradient_color);
+    background-image: linear-gradient(to bottom, $googleplus_main_color, $gradient_color);
+    background-image: -moz-linear-gradient(to bottom, $googleplus_main_color, $gradient_color);
+    background-image: -o-linear-gradient(to bottom, $googleplus_main_color, $gradient_color);
+    background-image: -webkit-linear-gradient(to bottom, $googleplus_main_color, $gradient_color);
+    background-image: -ms-linear-gradient(to bottom, $googleplus_main_color, $gradient_color);
     color: $text_white_color;
   }
   

--- a/src/providers/Line.vue
+++ b/src/providers/Line.vue
@@ -141,11 +141,11 @@
   
   // Button line style `gradient`
   .line__design__gradient {
-    background-image: linear-gradient(bottom, $line_main_color, $gradient_color);
-    background-image: -moz-linear-gradient(bottom, $line_main_color, $gradient_color);
-    background-image: -o-linear-gradient(bottom, $line_main_color, $gradient_color);
-    background-image: -webkit-linear-gradient(bottom, $line_main_color, $gradient_color);
-    background-image: -ms-linear-gradient(bottom, $line_main_color, $gradient_color);
+    background-image: linear-gradient(to bottom, $line_main_color, $gradient_color);
+    background-image: -moz-linear-gradient(to bottom, $line_main_color, $gradient_color);
+    background-image: -o-linear-gradient(to bottom, $line_main_color, $gradient_color);
+    background-image: -webkit-linear-gradient(to bottom, $line_main_color, $gradient_color);
+    background-image: -ms-linear-gradient(to bottom, $line_main_color, $gradient_color);
     color: $text_white_color;
   }
   

--- a/src/providers/LinkedIn.vue
+++ b/src/providers/LinkedIn.vue
@@ -219,11 +219,11 @@
   
   // Button linkedin style `gradient`
   .linkedin__design__gradient {
-    background-image: linear-gradient(bottom, $linkedin_main_color, $gradient_color);
-    background-image: -moz-linear-gradient(bottom, $linkedin_main_color, $gradient_color);
-    background-image: -o-linear-gradient(bottom, $linkedin_main_color, $gradient_color);
-    background-image: -webkit-linear-gradient(bottom, $linkedin_main_color, $gradient_color);
-    background-image: -ms-linear-gradient(bottom, $linkedin_main_color, $gradient_color);
+    background-image: linear-gradient(to bottom, $linkedin_main_color, $gradient_color);
+    background-image: -moz-linear-gradient(to bottom, $linkedin_main_color, $gradient_color);
+    background-image: -o-linear-gradient(to bottom, $linkedin_main_color, $gradient_color);
+    background-image: -webkit-linear-gradient(to bottom, $linkedin_main_color, $gradient_color);
+    background-image: -ms-linear-gradient(to bottom, $linkedin_main_color, $gradient_color);
     color: $text_white_color;
   }
   

--- a/src/providers/LiveJournal.vue
+++ b/src/providers/LiveJournal.vue
@@ -148,11 +148,11 @@
   
   // Button livejournal style `gradient`
   .livejournal__design__gradient {
-    background-image: linear-gradient(bottom, $livejournal_main_color, $gradient_color);
-    background-image: -moz-linear-gradient(bottom, $livejournal_main_color, $gradient_color);
-    background-image: -o-linear-gradient(bottom, $livejournal_main_color, $gradient_color);
-    background-image: -webkit-linear-gradient(bottom, $livejournal_main_color, $gradient_color);
-    background-image: -ms-linear-gradient(bottom, $livejournal_main_color, $gradient_color);
+    background-image: linear-gradient(to bottom, $livejournal_main_color, $gradient_color);
+    background-image: -moz-linear-gradient(to bottom, $livejournal_main_color, $gradient_color);
+    background-image: -o-linear-gradient(to bottom, $livejournal_main_color, $gradient_color);
+    background-image: -webkit-linear-gradient(to bottom, $livejournal_main_color, $gradient_color);
+    background-image: -ms-linear-gradient(to bottom, $livejournal_main_color, $gradient_color);
     color: $text_white_color;
   }
   

--- a/src/providers/MoiMir.vue
+++ b/src/providers/MoiMir.vue
@@ -225,11 +225,11 @@
   
   // Button moimir style `gradient`
   .moimir__design__gradient {
-    background-image: linear-gradient(bottom, $moimir_main_color, $gradient_color);
-    background-image: -moz-linear-gradient(bottom, $moimir_main_color, $gradient_color);
-    background-image: -o-linear-gradient(bottom, $moimir_main_color, $gradient_color);
-    background-image: -webkit-linear-gradient(bottom, $moimir_main_color, $gradient_color);
-    background-image: -ms-linear-gradient(bottom, $moimir_main_color, $gradient_color);
+    background-image: linear-gradient(to bottom, $moimir_main_color, $gradient_color);
+    background-image: -moz-linear-gradient(to bottom, $moimir_main_color, $gradient_color);
+    background-image: -o-linear-gradient(to bottom, $moimir_main_color, $gradient_color);
+    background-image: -webkit-linear-gradient(to bottom, $moimir_main_color, $gradient_color);
+    background-image: -ms-linear-gradient(to bottom, $moimir_main_color, $gradient_color);
     color: $text_white_color;
   }
   

--- a/src/providers/Odnoklassniki.vue
+++ b/src/providers/Odnoklassniki.vue
@@ -224,11 +224,11 @@
   
   // Button odnoklassniki style `gradient`
   .odnoklassniki__design__gradient {
-    background-image: linear-gradient(bottom, $odnoklassniki_main_color, $gradient_color);
-    background-image: -moz-linear-gradient(bottom, $odnoklassniki_main_color, $gradient_color);
-    background-image: -o-linear-gradient(bottom, $odnoklassniki_main_color, $gradient_color);
-    background-image: -webkit-linear-gradient(bottom, $odnoklassniki_main_color, $gradient_color);
-    background-image: -ms-linear-gradient(bottom, $odnoklassniki_main_color, $gradient_color);
+    background-image: linear-gradient(to bottom, $odnoklassniki_main_color, $gradient_color);
+    background-image: -moz-linear-gradient(to bottom, $odnoklassniki_main_color, $gradient_color);
+    background-image: -o-linear-gradient(to bottom, $odnoklassniki_main_color, $gradient_color);
+    background-image: -webkit-linear-gradient(to bottom, $odnoklassniki_main_color, $gradient_color);
+    background-image: -ms-linear-gradient(to bottom, $odnoklassniki_main_color, $gradient_color);
     color: $text_white_color;
   }
   

--- a/src/providers/Pinterest.vue
+++ b/src/providers/Pinterest.vue
@@ -217,11 +217,11 @@
   
   // Button pinterest style `gradient`
   .pinterest__design__gradient {
-    background-image: linear-gradient(bottom, $pinterest_main_color, $gradient_color);
-    background-image: -moz-linear-gradient(bottom, $pinterest_main_color, $gradient_color);
-    background-image: -o-linear-gradient(bottom, $pinterest_main_color, $gradient_color);
-    background-image: -webkit-linear-gradient(bottom, $pinterest_main_color, $gradient_color);
-    background-image: -ms-linear-gradient(bottom, $pinterest_main_color, $gradient_color);
+    background-image: linear-gradient(to bottom, $pinterest_main_color, $gradient_color);
+    background-image: -moz-linear-gradient(to bottom, $pinterest_main_color, $gradient_color);
+    background-image: -o-linear-gradient(to bottom, $pinterest_main_color, $gradient_color);
+    background-image: -webkit-linear-gradient(to bottom, $pinterest_main_color, $gradient_color);
+    background-image: -ms-linear-gradient(to bottom, $pinterest_main_color, $gradient_color);
     color: $text_white_color;
   }
   

--- a/src/providers/Reddit.vue
+++ b/src/providers/Reddit.vue
@@ -220,11 +220,11 @@
   
   // Button reddit style `gradient`
   .reddit__design__gradient {
-    background-image: linear-gradient(bottom, $reddit_main_color, $gradient_color);
-    background-image: -moz-linear-gradient(bottom, $reddit_main_color, $gradient_color);
-    background-image: -o-linear-gradient(bottom, $reddit_main_color, $gradient_color);
-    background-image: -webkit-linear-gradient(bottom, $reddit_main_color, $gradient_color);
-    background-image: -ms-linear-gradient(bottom, $reddit_main_color, $gradient_color);
+    background-image: linear-gradient(to bottom, $reddit_main_color, $gradient_color);
+    background-image: -moz-linear-gradient(to bottom, $reddit_main_color, $gradient_color);
+    background-image: -o-linear-gradient(to bottom, $reddit_main_color, $gradient_color);
+    background-image: -webkit-linear-gradient(to bottom, $reddit_main_color, $gradient_color);
+    background-image: -ms-linear-gradient(to bottom, $reddit_main_color, $gradient_color);
     color: $text_white_color;
   }
   

--- a/src/providers/Telegram.vue
+++ b/src/providers/Telegram.vue
@@ -141,11 +141,11 @@
   
   // Button telegram style `gradient`
   .telegram__design__gradient {
-    background-image: linear-gradient(bottom, $telegram_main_color, $gradient_color);
-    background-image: -moz-linear-gradient(bottom, $telegram_main_color, $gradient_color);
-    background-image: -o-linear-gradient(bottom, $telegram_main_color, $gradient_color);
-    background-image: -webkit-linear-gradient(bottom, $telegram_main_color, $gradient_color);
-    background-image: -ms-linear-gradient(bottom, $telegram_main_color, $gradient_color);
+    background-image: linear-gradient(to bottom, $telegram_main_color, $gradient_color);
+    background-image: -moz-linear-gradient(to bottom, $telegram_main_color, $gradient_color);
+    background-image: -o-linear-gradient(to bottom, $telegram_main_color, $gradient_color);
+    background-image: -webkit-linear-gradient(to bottom, $telegram_main_color, $gradient_color);
+    background-image: -ms-linear-gradient(to bottom, $telegram_main_color, $gradient_color);
     color: $text_white_color;
   }
   

--- a/src/providers/Tumblr.vue
+++ b/src/providers/Tumblr.vue
@@ -219,11 +219,11 @@
   
   // Button tumblr style `gradient`
   .tumblr__design__gradient {
-    background-image: linear-gradient(bottom, $tumblr_main_color, $gradient_color);
-    background-image: -moz-linear-gradient(bottom, $tumblr_main_color, $gradient_color);
-    background-image: -o-linear-gradient(bottom, $tumblr_main_color, $gradient_color);
-    background-image: -webkit-linear-gradient(bottom, $tumblr_main_color, $gradient_color);
-    background-image: -ms-linear-gradient(bottom, $tumblr_main_color, $gradient_color);
+    background-image: linear-gradient(to bottom, $tumblr_main_color, $gradient_color);
+    background-image: -moz-linear-gradient(to bottom, $tumblr_main_color, $gradient_color);
+    background-image: -o-linear-gradient(to bottom, $tumblr_main_color, $gradient_color);
+    background-image: -webkit-linear-gradient(to bottom, $tumblr_main_color, $gradient_color);
+    background-image: -ms-linear-gradient(to bottom, $tumblr_main_color, $gradient_color);
     color: $text_white_color;
   }
   

--- a/src/providers/Twitter.vue
+++ b/src/providers/Twitter.vue
@@ -148,11 +148,11 @@
   
   // Button twitter style `gradient`
   .twitter__design__gradient {
-    background-image: linear-gradient(bottom, $twitter_main_color, $gradient_color);
-    background-image: -moz-linear-gradient(bottom, $twitter_main_color, $gradient_color);
-    background-image: -o-linear-gradient(bottom, $twitter_main_color, $gradient_color);
-    background-image: -webkit-linear-gradient(bottom, $twitter_main_color, $gradient_color);
-    background-image: -ms-linear-gradient(bottom, $twitter_main_color, $gradient_color);
+    background-image: linear-gradient(to bottom, $twitter_main_color, $gradient_color);
+    background-image: -moz-linear-gradient(to bottom, $twitter_main_color, $gradient_color);
+    background-image: -o-linear-gradient(to bottom, $twitter_main_color, $gradient_color);
+    background-image: -webkit-linear-gradient(to bottom, $twitter_main_color, $gradient_color);
+    background-image: -ms-linear-gradient(to bottom, $twitter_main_color, $gradient_color);
     color: $text_white_color;
   }
   

--- a/src/providers/Viber.vue
+++ b/src/providers/Viber.vue
@@ -141,11 +141,11 @@
   
   // Button viber style `gradient`
   .viber__design__gradient {
-    background-image: linear-gradient(bottom, $viber_main_color, $gradient_color);
-    background-image: -moz-linear-gradient(bottom, $viber_main_color, $gradient_color);
-    background-image: -o-linear-gradient(bottom, $viber_main_color, $gradient_color);
-    background-image: -webkit-linear-gradient(bottom, $viber_main_color, $gradient_color);
-    background-image: -ms-linear-gradient(bottom, $viber_main_color, $gradient_color);
+    background-image: linear-gradient(to bottom, $viber_main_color, $gradient_color);
+    background-image: -moz-linear-gradient(to bottom, $viber_main_color, $gradient_color);
+    background-image: -o-linear-gradient(to bottom, $viber_main_color, $gradient_color);
+    background-image: -webkit-linear-gradient(to bottom, $viber_main_color, $gradient_color);
+    background-image: -ms-linear-gradient(to bottom, $viber_main_color, $gradient_color);
     color: $text_white_color;
   }
   

--- a/src/providers/Vkontakte.vue
+++ b/src/providers/Vkontakte.vue
@@ -240,11 +240,11 @@
   
   // Button Vkontakte style `gradient`
   .vkontakte__design__gradient {
-    background-image: linear-gradient(bottom, $vkontakte_main_color, $gradient_color);
-    background-image: -moz-linear-gradient(bottom, $vkontakte_main_color, $gradient_color);
-    background-image: -o-linear-gradient(bottom, $vkontakte_main_color, $gradient_color);
-    background-image: -webkit-linear-gradient(bottom, $vkontakte_main_color, $gradient_color);
-    background-image: -ms-linear-gradient(bottom, $vkontakte_main_color, $gradient_color);
+    background-image: linear-gradient(to bottom, $vkontakte_main_color, $gradient_color);
+    background-image: -moz-linear-gradient(to bottom, $vkontakte_main_color, $gradient_color);
+    background-image: -o-linear-gradient(to bottom, $vkontakte_main_color, $gradient_color);
+    background-image: -webkit-linear-gradient(to bottom, $vkontakte_main_color, $gradient_color);
+    background-image: -ms-linear-gradient(to bottom, $vkontakte_main_color, $gradient_color);
     color: $text_white_color;
   }
   

--- a/src/providers/WhatsApp.vue
+++ b/src/providers/WhatsApp.vue
@@ -141,11 +141,11 @@
   
   // Button whatsapp style `gradient`
   .whatsapp__design__gradient {
-    background-image: linear-gradient(bottom, $whatsapp_main_color, $gradient_color);
-    background-image: -moz-linear-gradient(bottom, $whatsapp_main_color, $gradient_color);
-    background-image: -o-linear-gradient(bottom, $whatsapp_main_color, $gradient_color);
-    background-image: -webkit-linear-gradient(bottom, $whatsapp_main_color, $gradient_color);
-    background-image: -ms-linear-gradient(bottom, $whatsapp_main_color, $gradient_color);
+    background-image: linear-gradient(to bottom, $whatsapp_main_color, $gradient_color);
+    background-image: -moz-linear-gradient(to bottom, $whatsapp_main_color, $gradient_color);
+    background-image: -o-linear-gradient(to bottom, $whatsapp_main_color, $gradient_color);
+    background-image: -webkit-linear-gradient(to bottom, $whatsapp_main_color, $gradient_color);
+    background-image: -ms-linear-gradient(to bottom, $whatsapp_main_color, $gradient_color);
     color: $text_white_color;
   }
   


### PR DESCRIPTION
this should fix the **Gradient has outdated direction syntax errors** when building a project, e.g.:

Module Warning (from ./node_modules/postcss-loader/lib/index.js):
(Emitted value instead of an instance of Error) autoprefixer: /node_modules/vue-goodshare/src/providers/Twitter.vue:53:3: Gradient has outdated direction syntax. New syntax is like `to left` instead of `right`.


